### PR TITLE
Add an option to not clear after attach

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -213,8 +213,9 @@ attach_main(int noerror)
 	cur_term.c_cc[VTIME] = 0;
 	tcsetattr(0, TCSADRAIN, &cur_term);
 
-	/* Clear the screen. This assumes VT100. */
-	write(1, "\33[H\33[J", 6);
+	/* Clear the screen, if the option is set. This assumes VT100. */
+  if (clear_after_attach)
+	  write(1, "\33[H\33[J", 6);
 
 	/* Tell the master that we want to attach. */
 	memset(&pkt, 0, sizeof(struct packet));

--- a/dtach.h
+++ b/dtach.h
@@ -81,7 +81,7 @@
 #endif
 
 extern char *progname, *sockname;
-extern int detach_char, no_suspend, redraw_method;
+extern int detach_char, no_suspend, redraw_method, clear_after_attach;
 extern struct termios orig_term;
 extern int dont_have_tty;
 

--- a/main.c
+++ b/main.c
@@ -36,6 +36,8 @@ int detach_char = '\\' - 64;
 int no_suspend;
 /* The default redraw method. Initially set to unspecified. */
 int redraw_method = REDRAW_UNSPEC;
+/* 1 if we don't want to clear the terminal after attaching */
+int clear_after_attach = 1;
 
 /*
 ** The original terminal settings. Shared between the master and attach
@@ -69,6 +71,7 @@ usage()
 		"  -p\t\tCopy the contents of standard input to the specified\n"
 		"\t\t  socket.\n"
 		"Options:\n"
+    "  -C\t\tDon't clear the terminal after attaching.\n"
 		"  -e <char>\tSet the detach character to <char>, defaults "
 		"to ^\\.\n"
 		"  -E\t\tDisable the detach character.\n"
@@ -158,6 +161,8 @@ main(int argc, char **argv)
 				detach_char = -1;
 			else if (*p == 'z')
 				no_suspend = 1;
+      else if (*p == 'C')
+        clear_after_attach = 0;
 			else if (*p == 'e')
 			{
 				++argv; --argc;


### PR DESCRIPTION
I'm trying to make a "pick up where I left off but don't mess with my scrollback buffers" kind of setup here. To this end, I'm using dtach with script and scriptreplay to store session output and replay it to my terminal.

The only hitch is that dtach normally clears the screen when it attaches -- normally, this is nice behavior, but in this case it clears the stuff that just played back.

So! This adds a -C option to dtach, which tells it _not_ to clear the screen after attaching to an active session.

Might fix https://github.com/crigler/dtach/issues/6